### PR TITLE
[bugfix] Hiding html tags on yeld views

### DIFF
--- a/views/layout.slim
+++ b/views/layout.slim
@@ -30,7 +30,7 @@ html lang="en"
       section.welcome.grid_12
         h1 Sinatra + Mongoid prototyping application.
         hr
-        = yield
+        == yield
   
   script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js"
   script type="text/javascript" src="/javascripts/application.js"


### PR DESCRIPTION
Hi!,
I found this bug trying your bootstrap. Yield views were showing <p> tags.

[offtopic] this is a great point to start with sinatra+mongo, thanks![/offtopic]
